### PR TITLE
Changed setup/install instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,7 @@
 xmpp-client setup
 =================
 
-go get
-go build
+    go get github.com/agl/xmpp-client
 
 xmpp-client use
 ===============


### PR DESCRIPTION
I think this is what you meant? :-)

As you probably know, but just in case -- `go get` downloads _and_ compiles Go code, and so never needs to be followed by a `go build`.
