### PR TITLE
Allows OTR chat with smarter OTR clients

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -430,7 +430,9 @@ MainLoop:
 				// messages with a whitespace tag that
 				// indicates that we support OTR.
 				if config.OTRAutoAppendTag && (!bytes.Contains(message, []byte("?OTR"))) {
-					message = append(message, OTRWhitespaceTag...)
+					if !conversation.IsEncrypted() {
+						message = append(message, OTRWhitespaceTag...)
+					}
 				}
 				if ok {
 					var err error


### PR DESCRIPTION
It turns out that we were unable to chat with bitlbee when OTR was enabled. This is likely to fix other OTR issues as well.
