### PR TITLE
Bell on message receipt

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	KnownFingerprints   []KnownFingerprint
 	RawLogFile          string   `json:",omitempty"`
 	NotifyCommand       []string `json:",omitempty"`
+	Bell                bool
 	UseTor              bool
 	OTRAutoTearDown     bool
 	OTRAutoAppendTag    bool

--- a/ui.go
+++ b/ui.go
@@ -727,6 +727,9 @@ func (s *Session) processClientMessage(stanza *xmpp.ClientMessage) {
 	line = append(line, s.term.Escape.Reset...)
 	line = append(line, out...)
 	line = append(line, '\n')
+	if s.config.Bell {
+		line = append(line, '\a')
+	}
 	s.term.Write(line)
 	s.maybeNotify()
 }


### PR DESCRIPTION
This patch causes the client to print a terminal bell character when it receives a message. It is configurable through the "Bell" configuration option in the config file, and is disabled by default. (If accepted, it might be a decent idea to add a /bell command to toggle the behavior)

I needed this personally because I run xmpp-client in a tmux session and would like to easily be able see when I have new messages.
