### PR TITLE
Add additional Hidden Service to config.go for Riseup! chat service

### DIFF
--- a/config.go
+++ b/config.go
@@ -167,6 +167,16 @@ func enroll(config *Config, term *terminal.Terminal) bool {
 		return true
 	}
 
+	if domain == "riseup.net" && config.UseTor == true {
+		const torProxyURL = "socks5://127.0.0.1:9050"
+		info(term, "It appears that you are using a well known server and we will use its Tor hidden service to connect.")
+		config.Server = "ztmc4p37hvues222.onion"
+		config.Port = 5222
+		config.Proxies = []string{torProxyURL}
+		term.SetPrompt("> ")
+		return true
+	}
+
 	var proxyStr string
 	term.SetPrompt("Proxy (i.e socks5://127.0.0.1:9050, enter for none): ")
 


### PR DESCRIPTION
The current Riseup! hidden service is:

  ztmc4p37hvues222.onion

This .onion comes from the Riseup! chat documentation page:

  https://www.riseup.net/en/chat
