### PR TITLE
Make seeing status updates configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	RawLogFile          string   `json:",omitempty"`
 	NotifyCommand       []string `json:",omitempty"`
 	Bell                bool
+	HideStatusUpdates   bool
 	UseTor              bool
 	OTRAutoTearDown     bool
 	OTRAutoAppendTag    bool

--- a/input.go
+++ b/input.go
@@ -33,6 +33,7 @@ var uiCommands = []uiCommand{
 	{"otr-start", otrCommand{}, "Start an OTR session with the given user"},
 	{"otr-info", otrInfoCommand{}, "Print OTR information such as OTR fingerprint"},
 	{"version", versionCommand{}, "Ask a Jabber client for its version"},
+	{"statusupdates", toggleStatusUpdatesCommand{}, "Toggle if status updates are displayed"},
 }
 
 type addCommand struct {
@@ -87,6 +88,8 @@ type msgCommand struct {
 	to  string
 	msg string
 }
+
+type toggleStatusUpdatesCommand struct{}
 
 func parseCommandForCompletion(commands []uiCommand, line []byte) (before, prefix []byte, isCommand, ok bool) {
 	if len(line) == 0 || line[0] != '/' {


### PR DESCRIPTION
With large rosters, the communication signal can get lost in the noise of
joins/parts/aways ( as pointed out in agl/xmpp-client#19 ). This commit adds a
/statusupdates command that toggles seeing these updates.

It is done in such a way that the default behavior is unchanged, so users who
don't care won't see any difference.
