### PR TITLE
Print [--flag] instead of <argname> for optinal arguments in /help.

### DIFF
--- a/input.go
+++ b/input.go
@@ -428,7 +428,11 @@ func (input *Input) showHelp() {
 		line := "/" + cmd.name
 		prototype := reflect.TypeOf(cmd.prototype)
 		for j := 0; j < prototype.NumField(); j++ {
-			line += " <" + strings.ToLower(prototype.Field(j).Name) + ">"
+			if strings.HasPrefix(string(prototype.Field(j).Tag), "flag:") {
+				line += " [--" + strings.ToLower(string(prototype.Field(j).Tag[5:])) + "]"
+			} else {
+				line += " <" + strings.ToLower(prototype.Field(j).Name) + ">"
+			}
 		}
 		if l := len(line); l > maxLen {
 			maxLen = l


### PR DESCRIPTION
This makes /help to print

```
...
* (9:19PM) /roster [--online]                     Display the current roster
...
```

instead of 

```
...
* (9:19PM) /roster <onlineonly>              Display the current roster
...
```
