### PR TITLE
Pass a custom TLS Configuration

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/xml"
 	"errors"
@@ -308,6 +309,15 @@ func main() {
 		TrustedAddress:          addrTrusted,
 		Archive:                 false,
 		ServerCertificateSHA256: certSHA256,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS10,
+			CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA},
+		},
 	}
 
 	if len(config.RawLogFile) > 0 {


### PR DESCRIPTION
Pass a custom `tls.Config` to the `xmpp` library to improve the security of the
connection.

The two things that the custom configuration does are:
  * Set the minimum TLS version to TLS 1.0 (as opposed to SSLv3)
  * Sets a custom set of CipherSuites which:
    * Require forward secrecy
    * Do not use RC4
    * Does still send `TLS_FALLBACK_SCSV`

Note: This could potentially break some people's connection if their XMPP server
only supports SSLv3 or does not support any of the cipher suites chosen.

This patch depends on agl/xmpp#22