### PR TITLE
/roster [--all] instead of /roster [--online]

### DIFF
--- a/input.go
+++ b/input.go
@@ -87,7 +87,7 @@ type quitCommand struct {
 }
 
 type rosterCommand struct {
-	OnlineOnly bool "flag:online"
+	AllContacts bool "flag:all"
 }
 
 type rosterEditCommand struct{}

--- a/ui.go
+++ b/ui.go
@@ -480,7 +480,7 @@ MainLoop:
 					line := ""
 					if ok {
 						line += "[*] "
-					} else if cmd.OnlineOnly {
+					} else if !cmd.AllContacts {
 						continue
 					} else {
 						line += "[ ] "


### PR DESCRIPTION
This PR changes `/roster` to always behave as `/roster --online` did previously.
Instead `/roster --all` now behaves as `/roster` did previously.

I have no idea how other people use xmpp-client, but for me this works a lot better. When using `/roster` I am basically always interested in seeing which contacts are online.