### PR TITLE
Fix apparmor profile for usage with enabled NotificationCommand

### DIFF
--- a/xmpp-client.apparmor
+++ b/xmpp-client.apparmor
@@ -11,6 +11,10 @@
   #include <abstractions/consoles>
   #include <abstractions/ssl_certs>
 
+  # Define additional allow rules for NotificationCommand binaries
+  # in a local override rule file.
+  #include <local/xmpp-client_notifiers
+
   # IPv4 TCP
   network inet stream,
   # We disable the following to enforce Tor usage
@@ -26,6 +30,9 @@
 
   # Allow reading of libs and /tmp
   /etc/ld.so.cache r,
+
+  # Needed for NotifyCommand's stdin/out/err
+  /dev/null rw,
 
   # Random number generation requires these two
   /dev/random r,


### PR DESCRIPTION
**Changes:**
* Allow rw for /dev/null, which is used as stdin/out/err for the configured NotificationCommand.
* Add include for local apparmor override file, where rules for the notification command binary can be added by the local administrator without touching the included profile for xmpp-client itself.

**Remarks:**

The local include could also point to a more default location (for most distros, this would probably be `<local/usr.bin.xmpp-client>`), but since the included apparmor profile is not named `usr.bin.xmpp-client` at the moment, this might be left to downstream distributors.
If desired, I could write a paragraph for the README describing how to setup the apparmor profile with enabled NotificationCommand. I tested the updated profile with a custom local override file for my NotificationCommand using debian sid and did not experience any problems.