### PR TITLE
Add DuckDuckGo's XMPP hidden service

### DIFF
--- a/config.go
+++ b/config.go
@@ -198,6 +198,7 @@ func enroll(config *Config, term *terminal.Terminal) bool {
 		"jabber.otr.im":             "5rgdtlawqkcplz75.onion",
 		"wtfismyip.com":             "ofkztxcohimx34la.onion",
 		"rows.io":                   "yz6yiv2hxyagvwy6.onion",
+		"DuckDuckGo":                "wlcpmruglhxp6quz.onion",
 	}
 
 	// Autoconfigure well known Tor hidden services.


### PR DESCRIPTION
Adding DuckDuckGo's XMPP hidden service server.

Provider: DuckDuckGo
Onion: wlcpmruglhxp6quz.onion
Source: https://twitter.com/runasand/status/636278183600484356