### PR TITLE
Non-OTR MUC support

### DIFF
--- a/input.go
+++ b/input.go
@@ -27,6 +27,8 @@ var uiCommands = []uiCommand{
 	{"help", helpCommand{}, "List known commands"},
 	{"ignore", ignoreCommand{}, "Ignore messages from another user"},
 	{"ignore-list", ignoreListCommand{}, "List currently ignored users"},
+	{"join", joinCommand{}, "Join a Multi-User-Chat"},
+	{"leave", leaveCommand{}, "Leave a Multi-User-Chat"},
 	{"nopaste", noPasteCommand{}, "Stop interpreting text verbatim"},
 	{"online", onlineCommand{}, "Set your status to Available / Online"},
 	{"otr-auth", authCommand{}, "Authenticate a secure peer with a mutual, shared secret"},
@@ -91,6 +93,14 @@ type ignoreCommand struct {
 }
 
 type ignoreListCommand struct{}
+
+type joinCommand struct {
+	User string "uid"
+}
+
+type leaveCommand struct {
+	User string "uid"
+}
 
 type msgCommand struct {
 	to  string

--- a/ui.go
+++ b/ui.go
@@ -558,6 +558,12 @@ MainLoop:
 				s.handleConfirmOrDeny(cmd.User, false /* deny */)
 			case addCommand:
 				s.conn.SendPresence(cmd.User, "subscribe", "" /* generate id */)
+			case joinCommand:
+				info(s.term, fmt.Sprintf("Warning: OTR is ***NOT SUPPORTED*** for Multi-User-Chats"))
+				s.conn.JoinMUC(cmd.User, "", "")
+			case leaveCommand:
+				s.conn.LeaveMUC(cmd.User)
+
 			case msgCommand:
 				conversation, ok := s.conversations[cmd.to]
 				isEncrypted := ok && conversation.IsEncrypted()
@@ -588,6 +594,7 @@ MainLoop:
 				} else {
 					msgs = [][]byte{[]byte(message)}
 				}
+
 				for _, message := range msgs {
 					s.conn.Send(cmd.to, string(message))
 				}
@@ -930,6 +937,12 @@ func (s *Session) processClientMessage(stanza *xmpp.ClientMessage) {
 				detectedOTRVersion = 3
 			}
 		}
+	}
+
+	// MultiParty OTR does not exist yet unfortunately
+	// Thus do not note we are going to try it
+	if stanza.Type == "groupchat" {
+		detectedOTRVersion = 0
 	}
 
 	if s.config.OTRAutoStartSession && detectedOTRVersion >= 2 {

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -383,7 +383,7 @@ func certName(cert *x509.Certificate) string {
 func Resolve(domain string) (host string, port uint16, err error) {
 	_, addrs, err := net.LookupSRV("xmpp-client", "tcp", domain)
 	if err != nil {
-		return "", 0, err
+		return domain, 5222, nil
 	}
 	if len(addrs) == 0 {
 		return "", 0, errors.New("xmpp: no SRV records found for " + domain)


### PR DESCRIPTION
Simple additions to get MUC support into xmpp-client.

As there is no published Multiparty OTR protocol though (afaik....) OTR is disabled and the user gets a warning when they use the /join command.
