### PR TITLE
Add I/O timeouts.

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -422,10 +422,14 @@ func main() {
 	info(term, fmt.Sprintf("Your fingerprint is %x", s.privateKey.Fingerprint()))
 
 	ticker := time.NewTicker(1 * time.Second)
+	pingTicker := time.NewTicker(60 * time.Second)
 
 MainLoop:
 	for {
 		select {
+		case <-pingTicker.C:
+			// Send periodic pings so that we can detect connection timeouts.
+			s.conn.Ping()
 		case now := <-ticker.C:
 			haveExpired := false
 			for _, expiry := range s.timeouts {


### PR DESCRIPTION
Currently, if a connection dies quietly, for instance because a laptop was
suspended, xmpp-client won't notice, and will appear to still be connected.

This change adds one-minute pings and a three-minute timeout on the net.Conn. If
the timeout is exceeded, xmpp-client will exit with an error, offering an
opportunity to restart (either manually or automatically).
