### PR TITLE
Add the onion address for Tor Project XMPP service

### DIFF
--- a/config.go
+++ b/config.go
@@ -198,6 +198,7 @@ func enroll(config *Config, term *terminal.Terminal) bool {
 		"jabber.otr.im":             "5rgdtlawqkcplz75.onion",
 		"wtfismyip.com":             "ofkztxcohimx34la.onion",
 		"rows.io":                   "yz6yiv2hxyagvwy6.onion",
+		"torproject.org":	     "k2r67kry5haud25b.onion",
 	}
 
 	// Autoconfigure well known Tor hidden services.


### PR DESCRIPTION
Citation: https://lists.torproject.org/pipermail/tor-project/2016-February/000064.html